### PR TITLE
Update README.md: Adding info about output

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Twig Quality Inspections is an extension to the [Twig templating](https://github
 which adds static analysis (i.e., compile-time) inspections and runtime assertions to increase templates' quality.
 See the [inspections section](#Inspections) below for details.
 
+What this tool will do is to show Symfony's red error page in the DEV environment whenever it encounters an error.
+There's no runner, there's no output (yet).
+
 Unlike other projects like [curlylint](https://www.curlylint.org/) and [djLint](https://www.djlint.com/docs/linter/),
 which focus on HTML, this tool exclusively analyzes the Twig code.
 


### PR DESCRIPTION
See https://github.com/alisqi/TwigQI/issues/3#issuecomment-2766373509

I've never used Twig outside Symfony. Is this a common use-case? If yes, how are the errors shown then?

Since installation differs between Symfony and Non-Symfony, maybe it would be better to split README in 3 parts?:
* Infos for Symfony users
* Infos for Non-Symfony users
* General info for everybody