### PR TITLE
Fix/is defined test deprecation

### DIFF
--- a/src/Inspection/InvalidConstant.php
+++ b/src/Inspection/InvalidConstant.php
@@ -9,6 +9,7 @@ use Psr\Log\LoggerInterface;
 use Twig\Environment;
 use Twig\Node\Expression\ConstantExpression;
 use Twig\Node\Expression\FunctionExpression;
+use Twig\Node\Expression\SupportDefinedTestInterface;
 use Twig\Node\Expression\Test\ConstantTest;
 use Twig\Node\Expression\Variable\ContextVariable;
 use Twig\Node\Node;
@@ -40,7 +41,7 @@ class InvalidConstant implements NodeVisitorInterface
         // ignore `constant('foo') is defined`
         if (
             $node instanceof FunctionExpression &&
-            $node->getAttribute('is_defined_test')
+            $this->isDefinedTestEnabled($node)
         ) {
             return;
         }
@@ -60,6 +61,19 @@ class InvalidConstant implements NodeVisitorInterface
         if ($error) {
             $this->logger->error("Invalid constant() call: $error (at $location)");
         }
+    }
+
+    /**
+     * Twig 3.21 deprecated the `is_defined_test` attribute in favor of `isDefinedTestEnabled()`.
+     * The interface does not exist in Twig < 3.21, which this library still supports.
+     */
+    private function isDefinedTestEnabled(FunctionExpression $node): bool
+    {
+        if ($node instanceof SupportDefinedTestInterface) {
+            return $node->isDefinedTestEnabled();
+        }
+
+        return (bool)$node->getAttribute('is_defined_test');
     }
 
     private function checkConstant(Node $node): ?string

--- a/src/Inspection/InvalidConstant.php
+++ b/src/Inspection/InvalidConstant.php
@@ -66,6 +66,8 @@ class InvalidConstant implements NodeVisitorInterface
     /**
      * Twig 3.21 deprecated the `is_defined_test` attribute in favor of `isDefinedTestEnabled()`.
      * The interface does not exist in Twig < 3.21, which this library still supports.
+     *
+     * TODO: unnecessary check for Twig >= 3.21.0
      */
     private function isDefinedTestEnabled(FunctionExpression $node): bool
     {

--- a/src/Inspection/UndeclaredVariableInMacro.php
+++ b/src/Inspection/UndeclaredVariableInMacro.php
@@ -135,6 +135,8 @@ class UndeclaredVariableInMacro implements NodeVisitorInterface
     /**
      * Twig 3.21 deprecated the `is_defined_test` attribute in favor of `isDefinedTestEnabled()`.
      * The interface does not exist in Twig < 3.21, which this library still supports.
+     *
+     * TODO: unnecessary check for Twig >= 3.21.0
      */
     private function isDefinedTestEnabled(ContextVariable $node): bool
     {

--- a/src/Inspection/UndeclaredVariableInMacro.php
+++ b/src/Inspection/UndeclaredVariableInMacro.php
@@ -7,6 +7,7 @@ namespace AlisQI\TwigQI\Inspection;
 use Psr\Log\LoggerInterface;
 use Twig\Environment;
 use Twig\Node\Expression\ArrowFunctionExpression;
+use Twig\Node\Expression\SupportDefinedTestInterface;
 use Twig\Node\Expression\Variable\ContextVariable;
 use Twig\Node\ForNode;
 use Twig\Node\MacroNode;
@@ -113,7 +114,7 @@ class UndeclaredVariableInMacro implements NodeVisitorInterface
         $variableName = $node->getAttribute('name');
 
         if (
-            !$node->getAttribute('is_defined_test') &&
+            !$this->isDefinedTestEnabled($node) &&
             $variableName !== '_self' &&
             !str_starts_with($variableName, '__internal') &&
             !in_array($variableName, $this->declaredVariableNames, false) &&
@@ -129,6 +130,19 @@ class UndeclaredVariableInMacro implements NodeVisitorInterface
                 ),
             );
         }
+    }
+
+    /**
+     * Twig 3.21 deprecated the `is_defined_test` attribute in favor of `isDefinedTestEnabled()`.
+     * The interface does not exist in Twig < 3.21, which this library still supports.
+     */
+    private function isDefinedTestEnabled(ContextVariable $node): bool
+    {
+        if ($node instanceof SupportDefinedTestInterface) {
+            return $node->isDefinedTestEnabled();
+        }
+
+        return (bool)$node->getAttribute('is_defined_test');
     }
 
     public function getPriority(): int


### PR DESCRIPTION
## Problem

Twig 3.21 deprecated the `is_defined_test` node attribute in favor of
`SupportDefinedTestInterface::isDefinedTestEnabled()`
([SupportDefinedTestDeprecationTrait](https://github.com/twigphp/Twig/blob/v3.28.0/src/Node/Expression/SupportDefinedTestDeprecationTrait.php)).

TwigQI still reads that attribute in two inspections, so on Twig >= 3.21 every template
compilation triggers `E_USER_DEPRECATED`:

- `InvalidConstant` — once per `constant()` call
- `UndeclaredVariableInMacro` — once per context variable inside a macro

For consumers this means a deprecation notice for effectively every affected template,
which floods logs and clutters deprecation reports.

It is not caught by CI because `composer.lock` pins `twig/twig v3.15.0`. Running the
existing test suite against Twig 3.21+ surfaces the problem: `AbstractTestCase` captures
deprecations through its `set_error_handler()`, so the notices turn into **25 test
failures**.

## Solution

Use `isDefinedTestEnabled()` when the node implements `SupportDefinedTestInterface`, and
keep reading the attribute otherwise.

The interface and the method were introduced in Twig 3.21, while `composer.json` allows
`twig/twig: ~3.15`, so the fallback is required for 3.15–3.20. `instanceof` on a
non-existent interface simply evaluates to `false`, so no version sniffing is needed.

```php
private function isDefinedTestEnabled(FunctionExpression $node): bool
{
    if ($node instanceof SupportDefinedTestInterface) {
        return $node->isDefinedTestEnabled();
    }

    return (bool)$node->getAttribute('is_defined_test');
}
```

The check is duplicated in both inspections rather than extracted into a helper, since the
node types differ (`FunctionExpression` vs. `ContextVariable`) and the whole thing can be
deleted once the minimum Twig requirement is >= 3.21.

## Testing

Existing suite, no changes needed — it already covers `constant('NOPE') is defined` and
`is defined` inside macros.

| twig/twig | before | after |
| --- | --- | --- |
| 3.15.0 | 303 passed | 303 passed |
| 3.20.0 | 303 passed | 303 passed |
| 3.21.0 | 25 failures | 303 passed |
| 3.28.0 | 25 failures | 303 passed |

Reproduce with:

```bash
composer update --with "twig/twig:^3.21" twig/twig
vendor/bin/phpunit
```

## Optional follow-up

CI currently runs against the locked Twig version only, which is why this slipped through.
A second job with a version matrix would catch regressions like this:

```yaml
  twig-versions:
    runs-on: ubuntu-latest
    strategy:
      fail-fast: false
      matrix:
        twig-version: [ '3.15.*', '3.20.*', '^3.21' ]
    name: PHPUnit with twig/twig ${{ matrix.twig-version }}
    steps:
      - uses: actions/checkout@v3
      - uses: shivammathur/setup-php@v2
        with:
          php-version: '8.2'
          coverage: none
      - run: composer update --with "twig/twig:${{ matrix.twig-version }}"
      - run: vendor/bin/phpunit
```